### PR TITLE
Check for uuids before publish

### DIFF
--- a/src/commands/uuids.js
+++ b/src/commands/uuids.js
@@ -3,13 +3,7 @@ const path = require('path');
 const { Command, flags } = require('@oclif/command');
 const c = require('ansi-colors');
 
-const {
-  createFileUuids,
-  getLibraryFiles,
-  getYamlFiles,
-  setLibraryFiles,
-  setYamlFiles,
-} = require('../lib');
+const { createUuids } = require('../tasks');
 
 class UuidsCommand extends Command {
   async run() {
@@ -22,6 +16,7 @@ class UuidsCommand extends Command {
     const libraryDirectory = path.resolve(cwd, libraryDir);
     const modulesDirectory = path.resolve(cwd, modulesDir);
     const programsDirectory = path.resolve(cwd, programsDir);
+    const options = { strict };
 
     this.log(`>> ${coloredAction} uuids`);
     this.log(`📍 cwd: ${c.blue(cwd)}`);
@@ -30,29 +25,12 @@ class UuidsCommand extends Command {
     this.log(`🏔 Programs: ${c.blue(programsDirectory)}`);
 
     try {
-      // Add uuids to library files
-      const libraryFiles = await getLibraryFiles(libraryDirectory);
-      const updatedLibraryFiles = await createFileUuids(libraryFiles, {
-        attributeName: 'attributes',
-        strict,
-      });
-
-      // Add uuids to module files
-      const moduleFiles = await getYamlFiles(modulesDirectory);
-      const updatedModuleFiles = await createFileUuids(moduleFiles, {
-        strict,
-      });
-
-      // Add uuids to program files
-      const programFiles = await getYamlFiles(programsDirectory);
-      const updatedProgramFiles = await createFileUuids(programFiles, {
-        strict,
-      });
-
-      // Replace all files. Do this after to ensure strict mode is observed
-      await setLibraryFiles(updatedLibraryFiles);
-      await setYamlFiles(updatedModuleFiles);
-      await setYamlFiles(updatedProgramFiles);
+      await createUuids(
+        libraryDirectory,
+        modulesDirectory,
+        programsDirectory,
+        options
+      );
 
       this.log(c.green('✅ All done!'));
     } catch (error) {

--- a/src/lib/uploadCurriculumToS3.js
+++ b/src/lib/uploadCurriculumToS3.js
@@ -3,13 +3,15 @@ const AWS = require('aws-sdk');
 
 const { S3_ACCESS_KEY, S3_BUCKET, S3_SECRET_KEY } = require('../config');
 
-const getKey = mod =>
-  `curricula/${mod.uuid}/${mod.code}/v${mod.version}/curriculum.json`;
+const getKey = curriculum =>
+  `curricula/${curriculum.uuid}/${curriculum.code}/v${
+    curriculum.version
+  }/curriculum.json`;
 
-const getParams = mod => ({
+const getParams = curriculum => ({
   Bucket: S3_BUCKET,
-  Key: getKey(mod),
-  Body: JSON.stringify(mod),
+  Key: getKey(curriculum),
+  Body: JSON.stringify(curriculum),
   ACL: 'public-read',
   ContentType: 'application/json',
 });
@@ -29,7 +31,7 @@ module.exports = curriculum => {
       if (err) reject(err);
       else {
         console.log(`Published curriculum ${c.green(params.Key)} to S3`);
-        resolve(mod);
+        resolve(curriculum);
       }
     });
   });

--- a/src/tasks/buildModules.js
+++ b/src/tasks/buildModules.js
@@ -6,7 +6,12 @@ const {
   getYamlFiles,
 } = require('../lib');
 
+const createUuids = require('./createUuids');
+
 module.exports = async (moduleDirectory, libraryDirectory) => {
+  // Check the library and modules for uuids
+  createUuids(libraryDirectory, moduleDirectory, null, { strict: true });
+
   // Get the module
   const mods = await getYamlFiles(moduleDirectory);
 

--- a/src/tasks/createUuids.js
+++ b/src/tasks/createUuids.js
@@ -12,29 +12,40 @@ module.exports = async (
   programsDirectory,
   options
 ) => {
-  const { strict } = options;
+  const { strict } = options || {};
 
   // Add uuids to library files
-  const libraryFiles = await getLibraryFiles(libraryDirectory);
-  const updatedLibraryFiles = await createFileUuids(libraryFiles, {
-    attributeName: 'attributes',
-    strict,
-  });
+  let updatedLibraryFiles;
+  if (libraryDirectory) {
+    const libraryFiles = await getLibraryFiles(libraryDirectory);
+    updatedLibraryFiles = await createFileUuids(libraryFiles, {
+      attributeName: 'attributes',
+      strict,
+    });
+  }
 
   // Add uuids to module files
-  const moduleFiles = await getYamlFiles(modulesDirectory);
-  const updatedModuleFiles = await createFileUuids(moduleFiles, {
-    strict,
-  });
+  let updatedModuleFiles;
+  if (modulesDirectory) {
+    const moduleFiles = await getYamlFiles(modulesDirectory);
+    updatedModuleFiles = await createFileUuids(moduleFiles, {
+      strict,
+    });
+  }
 
   // Add uuids to program files
-  const programFiles = await getYamlFiles(programsDirectory);
-  const updatedProgramFiles = await createFileUuids(programFiles, {
-    strict,
-  });
+  let updatedProgramFiles;
+  if (programsDirectory) {
+    const programFiles = await getYamlFiles(programsDirectory);
+    updatedProgramFiles = await createFileUuids(programFiles, {
+      strict,
+    });
+  }
 
-  // Replace all files. Do this after to ensure strict mode is observed
-  await setLibraryFiles(updatedLibraryFiles);
-  await setYamlFiles(updatedModuleFiles);
-  await setYamlFiles(updatedProgramFiles);
+  if (!strict) {
+    // Replace all files. Do this after to ensure strict mode is observed
+    if (updatedLibraryFiles) await setLibraryFiles(updatedLibraryFiles);
+    if (updatedModuleFiles) await setYamlFiles(updatedModuleFiles);
+    if (updatedProgramFiles) await setYamlFiles(updatedProgramFiles);
+  }
 };

--- a/src/tasks/createUuids.js
+++ b/src/tasks/createUuids.js
@@ -1,0 +1,40 @@
+const {
+  createFileUuids,
+  getLibraryFiles,
+  getYamlFiles,
+  setLibraryFiles,
+  setYamlFiles,
+} = require('../lib');
+
+module.exports = async (
+  libraryDirectory,
+  modulesDirectory,
+  programsDirectory,
+  options
+) => {
+  const { strict } = options;
+
+  // Add uuids to library files
+  const libraryFiles = await getLibraryFiles(libraryDirectory);
+  const updatedLibraryFiles = await createFileUuids(libraryFiles, {
+    attributeName: 'attributes',
+    strict,
+  });
+
+  // Add uuids to module files
+  const moduleFiles = await getYamlFiles(modulesDirectory);
+  const updatedModuleFiles = await createFileUuids(moduleFiles, {
+    strict,
+  });
+
+  // Add uuids to program files
+  const programFiles = await getYamlFiles(programsDirectory);
+  const updatedProgramFiles = await createFileUuids(programFiles, {
+    strict,
+  });
+
+  // Replace all files. Do this after to ensure strict mode is observed
+  await setLibraryFiles(updatedLibraryFiles);
+  await setYamlFiles(updatedModuleFiles);
+  await setYamlFiles(updatedProgramFiles);
+};

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -3,6 +3,7 @@ module.exports = {
   buildModules: require('./buildModules'),
   buildProgram: require('./buildProgram'),
   buildPrograms: require('./buildPrograms'),
+  createUuids: require('./createUuids'),
   publishModule: require('./publishModule'),
   publishModules: require('./publishModules'),
 };

--- a/src/tasks/publishModule.js
+++ b/src/tasks/publishModule.js
@@ -1,8 +1,12 @@
 const { getCurriculumFromModule, uploadCurriculumToS3 } = require('../lib');
 
 const buildModule = require('./buildModule');
+const createUuids = require('./createUuids');
 
 module.exports = async (modulePath, libraryDirectory) => {
+  // Check the library for all uuids
+  createUuids(libraryDirectory, null, null, { strict: true });
+
   // build the module
   const mod = await buildModule(modulePath, libraryDirectory);
   log(`Built module "${mod.src}"`);


### PR DESCRIPTION
- Move uuid logic to a `task`
- Check for uuids before running builds on publish

This will fail the publish task if uuids are missing
