### PR TITLE
Show an error when there is no code defined.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thinkful/zapdos",
   "description": "Content and program structure build tool for Thinkful",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": {
     "name": "Thinkful"
   },

--- a/src/lib/postProgramStructure.js
+++ b/src/lib/postProgramStructure.js
@@ -16,7 +16,7 @@ module.exports = async program => {
     }
 
     log(
-      `Posting program "${program.name} [${program.code}]" (${
+      `Posting program "${program.name}" [${program.code}] (${
         program.uuid
       }) to ${PROGRAM_STRUCTURES_URL}`
     );

--- a/src/lib/postProgramStructure.js
+++ b/src/lib/postProgramStructure.js
@@ -16,7 +16,7 @@ module.exports = async program => {
     }
 
     log(
-      `Posting program "${program.name}" (${
+      `Posting program "${program.name} [${program.code}]" (${
         program.uuid
       }) to ${PROGRAM_STRUCTURES_URL}`
     );
@@ -27,14 +27,14 @@ module.exports = async program => {
 
     log(
       `Successfully posted program "${
-        program.code
-      }" to ${PROGRAM_STRUCTURES_URL}: ${response.data}`
+        program.name
+      }" [${program.code}] to ${PROGRAM_STRUCTURES_URL}: ${response.data}`
     );
 
     return response.data;
   } catch (error) {
     log.error(
-      `Error posting program "${program.code}" (${program.uuid}): ${error}`
+      `Error posting program "${program.name}" [${program.code}] (${program.uuid}): ${error}`
     );
     throw error;
   }

--- a/src/lib/validateProgram.js
+++ b/src/lib/validateProgram.js
@@ -5,6 +5,15 @@ module.exports = async program => {
   if (!program.name) {
     error = `PROGRAM_INVALID: Program "${program.src}" has no name`;
   }
+
+  if (!program.code) {
+    if (program.slug) {
+      error = `PROGRAM_INVALID: Program ${program.src} has a 'slug' defined. Maybe you meant to use 'code'?`
+    } else {
+      error = `PROGRAM_INVALID: Program "${program.src}" has no 'code' defined`;
+    }
+  }
+
   if (!program.uuid) {
     error = `PROGRAM_INVALID: Program "${
       program.src

--- a/src/lib/validateProgram.js
+++ b/src/lib/validateProgram.js
@@ -8,9 +8,9 @@ module.exports = async program => {
 
   if (!program.code) {
     if (program.slug) {
-      error = `PROGRAM_INVALID: Program ${program.src} has a 'slug' defined. Maybe you meant to use 'code'?`
+      error = `PROGRAM_INVALID: Program ${program.src} has a "slug" defined. Maybe you meant to use "code"?`
     } else {
-      error = `PROGRAM_INVALID: Program "${program.src}" has no 'code' defined`;
+      error = `PROGRAM_INVALID: Program "${program.src}" has no "code" defined`;
     }
   }
 


### PR DESCRIPTION
We also check for `slug`, a common misnomer, to make for friendlier error messaging. Also includes other small logging improvements.