### PR TITLE
Allow PROD_BRANCH_NAME override for publishing to prod servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thinkful/zapdos",
   "description": "Content and program structure build tool for Thinkful",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": {
     "name": "Thinkful"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,7 @@
+const PROD_BRANCH_NAME = process.env.PROD_BRANCH_NAME || 'master';
+
 const DEPLOY_SERVER =
-  process.env.CIRCLE_BRANCH === 'master' ? 'PROD' : 'PREVIEW';
+  process.env.CIRCLE_BRANCH === PROD_BRANCH_NAME ? 'PROD' : 'PREVIEW';
 
 // Pull from different env vars based on branch
 module.exports = {


### PR DESCRIPTION
Part of https://chegg.atlassian.net/browse/TFOP-412

The new [test-immersion-programs repo](https://github.com/Thinkful-Ed/test-immersion-programs) uses `main` as its default branch instead of `master`. This allows the consumer to configure Zapdos to use a custom branch name for it's production build, while maintaining existing behavior for the other repos.